### PR TITLE
Video Capture Drone: Change a few prices and components

### DIFF
--- a/khrj.md
+++ b/khrj.md
@@ -61,26 +61,25 @@ Overview of generic components:
 
 ## Budget
 
-**Conversion Factor: $1 = ₹82.92**
+**Conversion Factor: $1 = ₹82.61**
 
 | Product                                       | Supplier/Link                                                                                                  | Cost                       |
 | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------------------- |
-| Arduino Due                                   | https://robu.in/product/arduino-due-arm-cortex-m3-cpu-board/                                                   | ₹3000                      |
+| Arduino Due                                   | https://robu.in/product/arduino-due-arm-cortex-m3-cpu-board/                                                   | ₹3400                      |
 | Raspberry Pi Pico W                           | https://robu.in/product/raspberry-pi-pico-w/                                                                   | ₹650                       |
 | Clone of TBS 500 Carbon Fiber Frame (has PDB) | https://robu.in/product/tbs-500-carbon-fiber-frame/                                                            | ₹2000                      |
 | 2x CW 2300KV BLDC Motor                       | https://robu.in/product/rs2205-2300kv-cw-brushless-motor-fpv-racing-quad-motor-fpv-multicopter-qav250-qav300/  | ₹1500                      |
 | 2x CCW 2300KV BLDC Motor                      | https://robu.in/product/rs2205-2300kv-ccw-brushless-motor-fpv-racing-quad-motor-fpv-multicopter-qav250-qav300/ | ₹1500                      |
 | 4x Standard 30A BLDC ESC                      | https://robu.in/product/standard-30a-bldc-esc-electronic-speed-controller/                                     | ₹2360                      |
 | 6x Pair of Glass Fiber Propeller              | https://robu.in/product/orange-hd-propellers-90459x4-5-glass-fiber-nylon-1cw1ccw-1pair-grey-2/                 | ₹900                       |
-| 6DoF IMU: DFRobot Fermion ICG 20660L          | https://robu.in/product/dfrobot-fermion-icg-20660l-accelgyro-6-axis-imu-module-breakout/                       | ₹1850                      |
-| 2x Antenna                                    | https://robu.in/product/433-mhz-2-5dbi-antenna/                                                                | ₹400                       |
+| 6DoF IMU: DFRobot Fermion ICG 20660L          | https://robu.in/product/dfrobot-fermion-icg-20660l-accelgyro-6-axis-imu-module-breakout/                       | ₹1950                      |
 | 2x NRF24L01 Transmitter + Antenna             | https://robu.in/product/2-4ghz-nrf24l01palna-sma-antenna-wireless-transceiver-communication-module-1km/        | ₹360                       |
 | 4200 mAh 3S LiPo Battery                      | https://robu.in/product/orange-4200mah-3s-35c-11-1-v-lithium-polymer-battery-pack-lipo/                        | ₹3000                      |
-| LiPo Battery Charger                          | https://www.amazon.in/Robocraze-Lipo-Battery-Charger-RC-A-011/dp/B071XK54XX                                    | ₹665                       |
 | RunCam Nano 3 800TVL                          | https://robu.in/product/runcam-nano-3-800tvl-camera/                                                           | ₹2000                      |
-| 2x Breadboard                                 | https://robu.in/product/transparent-830-points-solderless-breadboard/                                          | ₹270                       |
+| 2x Breadboard                                 | https://robu.in/product/transparent-830-points-solderless-breadboard/                                          | ₹220                       |
 | 65x M-M Jumpers                               | https://robu.in/product/65pcs-flexible-breadboard-jumper/                                                      | ₹103                       |
-| 50x zipties                                   | https://www.amazon.in/Plastic-Strip-250mm-Locking-Nylon/dp/B076WYNB8L?sbo=RZvfv%2F%2FHxDF%2BO5021pAnSA%3D%3D   | ₹125                       |
-| Video Transmitter                             |                                                                                                                | Self-funded                |
+| LiPo Battery Charger                          | https://www.amazon.in/Robotbanao-Balance-Charger-Robotics-Science/dp/B09J2BB8T8                                | ₹500                       |
+| 50x zipties                                   | https://www.amazon.in/Plastic-Strip-250mm-Locking-Nylon/dp/B076WYNB8L                                          | ₹125                       |
+| Video Transmitter + Relevant Antenna          |                                                                                                                | Self-funded                |
 | Video Receiver                                |                                                                                                                | Self-funded                | 
-| **Total**                                     |                                                                                                                | **₹20683 ≈ $249.28**       |
+| **Total**                                     |                                                                                                                | **₹20568 ≈ $249**       |


### PR DESCRIPTION
Conversion factor change: $1 = ₹82.92 ---> $1 = ₹82.61

Prices changed:
- Arduino Due went up by ₹400
- IMU went up by ₹100
- Battery charger seller was changed, net change down by ₹100
- Breadboard went down by ₹50

Components changed
- Generic antenna (not the one bundled with NRF24L01) was removed because it'll need to be purchased with the video transmitter to ensure compatibility. Total cost down by  ₹400

LiPo battery charger was moved from somewhere in the middle to the bottom to group with amazon items
The final cost is nearly the same, so no change in the grant is required